### PR TITLE
Potential fix for code scanning alert no. 2: DOM text reinterpreted as HTML

### DIFF
--- a/frontend/components/ImageInput.tsx
+++ b/frontend/components/ImageInput.tsx
@@ -12,11 +12,15 @@ const ImageInput: FC = () => {
 
   const handleFileChange = (event: any) => {
     const file = event.target.files[0];
-    if (file && file.type.substr(0, 5) === "image") {
+    const allowedImageTypes = ["image/png", "image/jpeg", "image/gif", "image/svg+xml"];
+
+    if (file && allowedImageTypes.includes(file.type)) {
       setImage(file);
-      setPreview(URL.createObjectURL(file));
+      const objectUrl = URL.createObjectURL(file);
+      setPreview(objectUrl);
     } else {
       setImage(null);
+      setPreview(""); // Reset preview for invalid files
     }
   };
 


### PR DESCRIPTION
Potential fix for [https://github.com/venkateshpabbati/Kidney-Disease-Classification-Deep-Learning-Project/security/code-scanning/2](https://github.com/venkateshpabbati/Kidney-Disease-Classification-Deep-Learning-Project/security/code-scanning/2)

The best way to fix this issue is to validate and sanitize the file before setting the `preview` state. This ensures that the file is indeed an image and does not contain unexpected or malicious content. Additionally, we should use a more defensive programming style to ensure that the `preview` value is safe before embedding it in the `src` attribute of an `<img>` tag.

- Validation: Check the MIME type of the file to confirm it belongs to a list of allowed image types (e.g., `image/png`, `image/jpeg`, etc.).
- Sanitization: Use an explicit whitelist approach to reject any unexpected file types or formats.
- Defensive usage: Ensure that the `src` attribute only receives safe, validated URLs.

We only need to make changes in the `handleFileChange` function to perform validation and adjust the logic accordingly.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
