### PR TITLE
Potential fix for code scanning alert no. 2: DOM text reinterpreted as HTML

### DIFF
--- a/frontend/components/ImageInput.tsx
+++ b/frontend/components/ImageInput.tsx
@@ -12,7 +12,7 @@ const ImageInput: FC = () => {
 
   const handleFileChange = (event: any) => {
     const file = event.target.files[0];
-    const allowedImageTypes = ["image/png", "image/jpeg", "image/gif", "image/svg+xml"];
+    const allowedImageTypes = ["image/png", "image/jpeg", "image/gif"];
 
     if (file && allowedImageTypes.includes(file.type)) {
       setImage(file);


### PR DESCRIPTION
Potential fix for [https://github.com/venkateshpabbati/Kidney-Disease-Classification-Deep-Learning-Project/security/code-scanning/2](https://github.com/venkateshpabbati/Kidney-Disease-Classification-Deep-Learning-Project/security/code-scanning/2)

The best way to mitigate the risk is to **eliminate SVG images from the accepted types**, thus preventing any possibility of SVG-borne XSS through `<img src>`. Alternatively, a robust SVG sanitizer could be employed, but simply not allowing SVG as a valid upload is simpler and safer. To implement this, update the `allowedImageTypes` array to remove `"image/svg+xml"`, so users can only upload `image/png`, `image/jpeg`, and `image/gif` images. This change is confined to the `allowedImageTypes` assignment in the `handleFileChange` function (lines 15–16).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
